### PR TITLE
Numerical Simulations

### DIFF
--- a/lower_bound.m
+++ b/lower_bound.m
@@ -1,0 +1,25 @@
+n = 20000;
+%n=100;
+%hard case?
+c=0.5; 
+A = zeros(n,n);
+%A(1:600,1:600) = -1;
+%top 40 magnitude eigenvalues. Safe to assume the smallest lies in this set.
+%lmin = eigs(A,40);
+ind=randperm(n,n*c);
+A(ind,ind)=-1;
+lmin=-(c*n);
+sizes = 50:50:2000;
+err = zeros(size(sizes));
+for i = 1:length(sizes)
+  for t = 1:40
+    ind = randperm(n,sizes(i));
+%     c_avg=
+%     lminS=-c_avg*n;
+%    lminS = eigs(A(ind,ind),40);
+    lminS = eigs(A(ind,ind),1,'smallestreal');
+    err(i) = err(i) + abs(n/sizes(i)*min(lminS)-lmin);
+  end
+end
+err = err/40;
+plot(log(sizes),log(err))

--- a/test.m
+++ b/test.m
@@ -1,0 +1,23 @@
+n = 2000;
+A = rand(n,n);
+%sparse binary matrix
+A = A > .99;
+%symmetrize
+A = triu(A) + triu(A)';
+%hard case?
+%A = zeros(n,n);
+%A(1:600,1:600) = -1;
+%top 40 magnitude eigenvalues. Safe to assume the smallest lies in this set.
+lmin = eigs(A,40);
+lmin = min(lmin);
+sizes = 50:50:1000;
+err = zeros(size(sizes));
+for i = 1:length(sizes)
+  for t = 1:10
+    ind = randperm(n,sizes(i));
+    lminS = eigs(A(ind,ind),40);
+    err(i) = err(i) + abs(n/sizes(i)*min(lminS)-lmin);
+  end
+end
+err = err/10;
+plot(log(sizes),log(err))


### PR DESCRIPTION
test.m: create a sparse binary matrix, symmetrize it and check how the estimation error of the smallest eigenvalue varies with submatrix size
lower_bound.m: out of n, choose cn indices (0<c<1) and set the submatrix corresponding to these cn indices to -1 and set the rest of the entries to 0. This case achieves the 1/eps^2 lower bound and I think can be put in the simulations section.